### PR TITLE
Add multiple items value into the tree of location

### DIFF
--- a/Sources/Sight/Items.swift
+++ b/Sources/Sight/Items.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+// Wrapper for region item value.
+public struct Items<T> {
+  
+  /// The value of the item that is a generic type/
+  public let value: T
+  
+  /// Item position represent on a coordinate
+  public let position: SIMD2<Float>
+    
+  /// Make the item is a public object
+  public init(value: T, position: SIMD2<Float>) {
+    self.value = value
+    self.position = position
+  }
+  
+}

--- a/Tests/SightTests/Region/RegionTests.swift
+++ b/Tests/SightTests/Region/RegionTests.swift
@@ -20,6 +20,25 @@ final class RegionTests: XCTestCase {
 
     XCTAssertEqual(value, region.closestValue(to: valuePosition))
   }
+    
+  func testMultipleValue() {
+    let region = Region<String>(
+      minBounds: SIMD2(x: 0, y: 0),
+      maxBounds: SIMD2(x: 1, y: 1),
+      searchRadius: 0.3
+    )
+
+    var items: [Items<String>] = []
+    let itemA = Items(value: "A", position: SIMD2(x: 0, y: 0.1))
+    let itemB = Items(value: "B", position: SIMD2(x: 0.5, y: 0))
+    let itemC = Items(value: "C", position: SIMD2(x: 0, y: 0.8))
+    items.append(itemA)
+    items.append(itemB)
+    items.append(itemC)
+    region.adds(items)
+
+    XCTAssertEqual(region.totalItems(), items.count)
+  }
 
   func testFindValueOnEdge() {
     let searchRadius: Float = 0.5


### PR DESCRIPTION
- Put an `Items` struct for define an item we want to put
- Add `adds(_ items)` method to make user able to insert multiple items in one shot with desirable wrapper
- Store the `locationBound` of current `Region`
- Able to calculate the total items inside the `Region` object for counting purpose
- Change method specifier into `private` for protect it properties to be modified internally

TODO : Add Documentation on README.md